### PR TITLE
Handle missing pdf writer binary (and add installing it to the instructions)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ This script automates the process of generating Security Static Analysis (SAST) 
 
 `pip install pandas requests fpdf pdfkit PyPDF2 plotly`
 
+3. (Optional) To get PDF output, install `wkhtmltopdf` from https://wkhtmltopdf.org/
+
 
 ## Configuration
 Before running the script, you must set up the `SEMGREP_API_WEB_TOKEN` environment variable with your Semgrep API token:

--- a/file_handling_helpers.py
+++ b/file_handling_helpers.py
@@ -685,7 +685,10 @@ def combine_html_files(severity_and_state_counts_all_repos, vulnerability_counts
         'orientation': 'Landscape',
         'enable-local-file-access': None
     }
-    pdfkit.from_string(combined_html, os.path.join(folder_path, output_pdf_filename), options=options)
+    try:
+        pdfkit.from_string(combined_html, os.path.join(folder_path, output_pdf_filename), options=options)
+    except OSError:
+        logging.info("Skipping PDF because wkhtmltopdf not found. You can get it here: https://wkhtmltopdf.org/")
 
 def generate_html_sast(df_high: pd.DataFrame, df_med: pd.DataFrame, df_low: pd.DataFrame, repo_name):
     # get the Overview table HTML from the dataframe

--- a/semgrep_findings_to_csv_html_pdf_all_repos_filter_tag.py
+++ b/semgrep_findings_to_csv_html_pdf_all_repos_filter_tag.py
@@ -399,7 +399,10 @@ def process_sast_findings(df: pd.DataFrame, html_filename, pdf_filename, repo_na
         'orientation': 'Landscape',
         'enable-local-file-access': None
     }
-    pdfkit.from_string(html, pdf_filename, options=options)
+    try:
+        pdfkit.from_string(html, pdf_filename, options=options)
+    except OSError:
+        logging.info("Skipping PDF because wkhtmltopdf not found. You can get it here: https://wkhtmltopdf.org/")
 
 def json_to_html_pandas(json_file, html_file, pdf_file, repo_name):
 


### PR DESCRIPTION
This isn't a super graceful solution, because it will still try to write an empty PDF when the package isn't present, but it at least prevents it from crashing.